### PR TITLE
Use Variant bound in eval_rusp

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.dependencies]
-rhai = { version = "1.16", features = ["serde"] }
+rhai = { version = "1.16", features = ["serde", "internals"] }
 rusp-lib = { version = "0.96", path = "rusp-lib" }
 rhai-rusp = { version = "0.96", path = "rhai-rusp" }
 

--- a/rhai-rusp/src/lib.rs
+++ b/rhai-rusp/src/lib.rs
@@ -8,7 +8,7 @@ use rhai::{
         FuncRegistration, ImmutableString, Module, NativeCallContext, PluginFunc, RhaiResult,
         TypeId,
     },
-    Array, Map,
+    Array, Map, Variant,
 };
 use rusp_lib::usp::{Body, Msg};
 use rusp_lib::usp_builder;
@@ -36,7 +36,7 @@ use rusp_lib::usp_record::{self, Record};
 /// the provided Rhai script fails to evaluate.
 pub fn eval_rusp<T>(str: &str) -> Result<T, String>
 where
-    T: Clone + 'static,
+    T: Variant + Clone,
 {
     use rhai::{packages::Package, Engine};
 

--- a/rusp-lib/src/usp_builder/delete.rs
+++ b/rusp-lib/src/usp_builder/delete.rs
@@ -46,7 +46,7 @@ impl DeleteBuilder {
                     req_type: delete({
                         Delete {
                             allow_partial: self.allow_partial,
-                            obj_paths: self.obj_paths.into_iter().map(Into::into).collect(),
+                            obj_paths: self.obj_paths,
                         }
                     }),
                 }
@@ -118,7 +118,7 @@ impl DeletedObjectResultsBuilder {
             oper_status: match self.oper_status {
                 DeleteRespOperationStatus::Success(s) => Some(OperationStatus {
                     oper_status: oper_success(OperationSuccess {
-                        affected_paths: s.affected_paths.into_iter().map(Into::into).collect(),
+                        affected_paths: s.affected_paths,
                         unaffected_path_errs: s
                             .unaffected_path_errs
                             .into_iter()

--- a/rusp-lib/src/usp_builder/deregister.rs
+++ b/rusp-lib/src/usp_builder/deregister.rs
@@ -33,15 +33,7 @@ impl DeregisterBuilder {
         Ok(Body {
             msg_body: request({
                 Request {
-                    req_type: deregister({
-                        Deregister {
-                            paths: self
-                                .paths
-                                .into_iter()
-                                .map(std::convert::Into::into)
-                                .collect(),
-                        }
-                    }),
+                    req_type: deregister(Deregister { paths: self.paths }),
                 }
             }),
         })
@@ -97,10 +89,7 @@ impl DeregisteredPathResultBuilder {
                 }),
                 DeregisterOperationStatus::Success(s) => Ok(OperationStatus {
                     oper_status: OneOfoper_status::oper_success(OperationSuccess {
-                        deregistered_path: s
-                            .into_iter()
-                            .map(std::convert::Into::into)
-                            .collect::<Vec<_>>(),
+                        deregistered_path: s,
                     }),
                 }),
                 DeregisterOperationStatus::None => Err(anyhow::anyhow!("")),

--- a/rusp-lib/src/usp_builder/get.rs
+++ b/rusp-lib/src/usp_builder/get.rs
@@ -42,7 +42,7 @@ impl GetBuilder {
                     req_type: get({
                         Get {
                             max_depth: self.max_depth,
-                            param_paths: self.params.into_iter().map(Into::into).collect(),
+                            param_paths: self.params,
                         }
                     }),
                 }

--- a/rusp-lib/src/usp_builder/getinstances.rs
+++ b/rusp-lib/src/usp_builder/getinstances.rs
@@ -41,7 +41,7 @@ impl GetInstancesBuilder {
                 Request {
                     req_type: get_instances({
                         GetInstances {
-                            obj_paths: self.obj_paths.into_iter().map(Into::into).collect(),
+                            obj_paths: self.obj_paths,
                             first_level_only: self.first_level_only,
                         }
                     }),

--- a/rusp-lib/src/usp_builder/getsupporteddm.rs
+++ b/rusp-lib/src/usp_builder/getsupporteddm.rs
@@ -78,11 +78,7 @@ impl GetSupportedDMBuilder {
                 Request {
                     req_type: get_supported_dm({
                         GetSupportedDM {
-                            obj_paths: self
-                                .obj_paths
-                                .into_iter()
-                                .map(std::convert::Into::into)
-                                .collect(),
+                            obj_paths: self.obj_paths,
                             first_level_only: self.first_level_only,
                             return_commands: self.return_commands,
                             return_events: self.return_events,
@@ -147,16 +143,8 @@ impl GSDMCommandResult {
         }
         Ok(SupportedCommandResult {
             command_name: self.command_name,
-            input_arg_names: self
-                .input_arg_names
-                .into_iter()
-                .map(std::convert::Into::into)
-                .collect(),
-            output_arg_names: self
-                .output_arg_names
-                .into_iter()
-                .map(std::convert::Into::into)
-                .collect(),
+            input_arg_names: self.input_arg_names,
+            output_arg_names: self.output_arg_names,
             command_type: self.command_type,
         })
     }
@@ -186,11 +174,7 @@ impl GSDMEventResult {
     pub fn build(self) -> Result<SupportedEventResult> {
         Ok(SupportedEventResult {
             event_name: self.event_name,
-            arg_names: self
-                .arg_names
-                .into_iter()
-                .map(std::convert::Into::into)
-                .collect(),
+            arg_names: self.arg_names,
         })
     }
 }
@@ -436,11 +420,7 @@ impl GSDMSupportedObjectResultBuilder {
             supported_commands,
             supported_events,
             supported_params,
-            divergent_paths: self
-                .divergent_paths
-                .into_iter()
-                .map(std::convert::Into::into)
-                .collect(),
+            divergent_paths: self.divergent_paths,
             unique_key_sets,
         })
     }


### PR DESCRIPTION
This allows us to properly compile with rhai features that change the `Variant` trait.